### PR TITLE
Fixbug #11 and add a new option `--json`

### DIFF
--- a/lib/cocoapods-dependency/command/dependency.rb
+++ b/lib/cocoapods-dependency/command/dependency.rb
@@ -2,6 +2,7 @@ require 'cocoapods-dependency/analyze'
 require 'pp'
 require 'cocoapods-dependency/visual_out'
 require 'tmpdir'
+require 'json'
 
 module Pod
   class Command
@@ -15,12 +16,14 @@ module Pod
 
       def initialize(argv)
         @using_visual_output = argv.flag?('visual', false)
+        @to_output_json = argv.flag?('json', false)
         super
       end
 
       def self.options
         [
           ['--visual', 'Output the result using html'],
+          ['--json', 'Output in JSON format']
         ].concat(super)
       end
 
@@ -41,7 +44,11 @@ module Pod
           puts "[CocoapodsDependency] ✅ html file generated at path #{final_html_path}"
           system "open #{final_html_path}"
         else
-          pp result
+          if @to_output_json
+            puts JSON.pretty_generate(analyze_result)
+          else
+            pp analyze_result
+          end
         end
       end
     end

--- a/lib/cocoapods-dependency/resources/index.html.erb
+++ b/lib/cocoapods-dependency/resources/index.html.erb
@@ -15,7 +15,6 @@
       }
 
       #nav {
-        padding: 10px 30px;
         float: left;
         width: 30%;
         height: 100%;
@@ -23,20 +22,16 @@
       }
 
       #content {
-        padding: 10px 30px;
         float: left;
         width: 60%;
         height: 100%;
         overflow: scroll;
-      }        
+      }
   </style>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
 
-  <body onload="pageDidLoad()">
   <script>
 
-    function loadJSON(fileName, callback) {   
+    function loadJSON(fileName, callback) {
       var xobj = new XMLHttpRequest();
       xobj.overrideMimeType("application/json");
       xobj.open('GET', fileName, true);
@@ -51,12 +46,14 @@
     function pageDidLoad() {
       loadJSON('index.json', response => {
         var actual_JSON = JSON.parse(response);
-
-        let podNames = actual_JSON.links.map(s => s.source);
-
-        renderNavs(podNames)
-        renderPods(actual_JSON.links)
+        loadData(actual_JSON);
       });
+    }
+
+    function loadData(actual_JSON) {
+      let podNames = actual_JSON.links.map(s => s.source);
+      renderNavs(podNames)
+      renderPods(actual_JSON.links)
     }
 
     function renderNavs(podNames) {
@@ -76,9 +73,9 @@
         let header = document.createElement('h3')
         header.innerHTML = element.source
         header.id = element.source
-        
+
         div.appendChild(header)
-        
+
         let ul = document.createElement('ul')
         let dependencies = element.dependencies.sort()
         dependencies.forEach(dependency => {
@@ -89,8 +86,8 @@
           ul.appendChild(li)
           li.appendChild(a)
         })
-      
-        div.appendChild(ul)      
+
+        div.appendChild(ul)
         d.appendChild(div)
       })
     }
@@ -105,6 +102,11 @@
   <div id="content">
     <div id="pods"></div>
   </div>
+
+  <script type="text/javascript">
+    var actual_JSON = <%= result %>;
+    loadData(actual_JSON);
+  </script>
 </body>
 
 </html>

--- a/lib/cocoapods-dependency/visual_out.rb
+++ b/lib/cocoapods-dependency/visual_out.rb
@@ -22,11 +22,20 @@ module CocoapodsDependency
       end
 
       json['links'] = links
-
       JSON.pretty_generate(json)
     end
 
     def write_json_to_file(path)
+      json_result = JSON.pretty_generate(dependency_hash)
+      File.write(path, json_result)
+    end
+
+    def write_d3js_to_file(path)
+      json = 'var dependencies = ' + to_d3js_json
+      File.write(path, json)
+    end
+
+    def dependency_hash
       links = []
       json = {}
       @dependency_map.each do |node, v|
@@ -38,13 +47,7 @@ module CocoapodsDependency
         )
       end
       json['links'] = links
-      json_result = JSON.pretty_generate(json)
-      File.write(path, json_result)
-    end
-
-    def write_d3js_to_file(path)
-      json = 'var dependencies = ' + to_d3js_json
-      File.write(path, json)
+      return json
     end
   end
 end


### PR DESCRIPTION
1. Fixbug #11 : use erb template to generate the HTML file and feed data into it as embedded JavaScript
修复bug #11 : JavaScript跨域问题。
使用Ruby erb模板生成HTML文件，并将数据以JSON格式插入；在HTML中被解释为JS代码，避免了跨域请求数据。

2. output in JSON format by adding a option `--json`
增加一个选项 `--json`，输出格式为 **JSON**